### PR TITLE
Change `--xunit` argument to more generic `--output-format xunit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,23 @@ The the main available options are:
 ```bash
 usage: wft4galaxy [-h] [--server GALAXY_URL] [--api-key GALAXY_API_KEY]
                   [-f FILE] [--enable-logger] [--debug] [--disable-cleanup]
-                  [--xunit] [--xunit-file FILE_PATH] [-o PATH]
+                  [--output-format {text,xunit}] [--xunit-file FILE_PATH] [-o PATH]
                   [test [test ...]]
 
 positional arguments:
   test                      Workflow Test Name
 
 optional arguments:
-  -h, --help                show this help message and exit
-  --server GALAXY_URL       Galaxy server URL
-  --api-key GALAXY_API_KEY  Galaxy server API KEY
-  -f FILE, --file FILE      YAML configuration file of workflow tests (default is workflow-test-suite.yml)
-  --enable-logger           Enable log messages
-  --debug                   Enable debug mode
-  --disable-cleanup         Disable cleanup
-  --xunit                   Enable xUnit report
-  --xunit-file FILE_PATH    Set the path of the xUnit report file (absolute or relative to the output folder)
-  -o PATH, --output PATH    Path of the output folder
-                        
+  -h, --help                    show this help message and exit
+  --server GALAXY_URL           Galaxy server URL
+  --api-key GALAXY_API_KEY      Galaxy server API KEY
+  -f FILE, --file FILE          YAML configuration file of workflow tests (default is workflow-test-suite.yml)
+  --enable-logger               Enable log messages
+  --debug                       Enable debug mode
+  --disable-cleanup             Disable cleanup
+  --output-format {text,xunit}  Choose output type
+  --xunit-file FILE_PATH        Set the path of the xUnit report file (absolute or relative to the output folder)
+  -o PATH, --output PATH        Path of the output folder
 ```
 
 As an example, you can run tests defined in your ``workflow-test-suite.yml`` definition file by typing:

--- a/wft4galaxy/app/docker_runner.py
+++ b/wft4galaxy/app/docker_runner.py
@@ -178,7 +178,10 @@ class _CommandLineHelper:
                                   .format(DEFAULT_OUTPUT_FOLDER))
         wft4g_parser.add_argument('--enable-logger', help='Enable log messages', action='store_true')
         wft4g_parser.add_argument('--disable-cleanup', help='Disable cleanup', action='store_true')
-        wft4g_parser.add_argument('--xunit', help='Enable xUnit report', action='store_true', default=False)
+
+        # here we hardcode the possible values of wft4galaxy.core.OutputFormat because we don't
+        # want to require installing the package to use the docker runner.
+        wft4g_parser.add_argument('--output-format', choices=tuple('text', 'xunit'), help='Choose output type', default='text')
         wft4g_parser.add_argument('--xunit-file', default=None, metavar="PATH",
                                   help='Set the path of the xUnit report file (absolute or relative to the output folder)')
         wft4g_parser.add_argument("test", help="Workflow Test Name", nargs="*")
@@ -414,11 +417,10 @@ class NonInteractiveContainer(Container):
             # cleanup option
             if options.disable_cleanup:
                 cmd.append("--disable-cleanup")
-            # xunit options
-            if options.xunit:
-                cmd.append("--xunit")
+            # output format options
+            cmd.extend( ('--output-format', options.output_format) )
             if options.xunit_file:
-                cmd += ["--xunit-file", options.xunit_file]
+                cmd.extend(("--xunit-file", options.xunit_file))
             # add test filter
             cmd += options.test
 

--- a/wft4galaxy/app/runner.py
+++ b/wft4galaxy/app/runner.py
@@ -7,6 +7,7 @@ import logging as _logging
 
 import wft4galaxy.core as _core
 import wft4galaxy.common as _common
+from wft4galaxy.core import OutputFormat
 
 # set logger
 _logger = _common.LoggerManager.get_logger(__name__)
@@ -31,7 +32,8 @@ def _make_parser():
     parser.add_argument('--debug', help='Enable debug mode', action='store_true', default=None)
     parser.add_argument('--disable-cleanup', help='Disable cleanup', action='store_true', default=None)
 
-    parser.add_argument('--xunit', help='Enable xUnit report', action='store_true', default=False)
+    parser.add_argument('--output-format', choices=tuple(OutputFormat), help='Choose output type', default=OutputFormat.text)
+
     parser.add_argument('--xunit-file', default=None, metavar="FILE_PATH",
                         help='Set the path of the xUnit report file (absolute or relative to the output folder)')
     parser.add_argument('-o', '--output', dest="output_folder", metavar="PATH", help='Path of the output folder')
@@ -46,6 +48,8 @@ def _parse_cli_arguments(parser, cmd_args):
         parser.error("Test file {} doesn't exist or isn't a file".format(args.file))
     if not _os.access(args.file, _os.R_OK):
         parser.error("Permission error.  Test file {} isn't accessible for reading".format(args.file))
+    if args.xunit_file and args.output_format != OutputFormat.xunit:
+        parser.error("--xunit-file can only be specified when using the xUnit output format")
 
     return args
 
@@ -157,7 +161,7 @@ def main():
                          enable_logger=options.enable_logger,
                          enable_debug=options.debug,
                          disable_cleanup=options.disable_cleanup,
-                         enable_xunit=options.xunit,
+                         enable_xunit=(options.output_format == OutputFormat.xunit),
                          xunit_file=options.xunit_file,
                          tests=options.test)
 

--- a/wft4galaxy/core.py
+++ b/wft4galaxy/core.py
@@ -18,6 +18,20 @@ import wft4galaxy.common as _common
 # set logger
 _logger = _common.LoggerManager.get_logger(__name__)
 
+# Enum magic for Python < 3.4
+class Enum(object):
+    def __init__(self, **enums):
+        for name, val in enums.iteritems():
+            self.__dict__[name] = val
+
+    def __setattr__(self, name, v):
+        raise StandardError("Setting enum value not allowed")
+
+    def __iter__(self):
+        return self.__dict__.iterkeys()
+
+# Define an Enum for supported output types
+OutputFormat = Enum(text='text', xunit='xunit')
 
 class FileFormats(object):
     YAML = "YAML"


### PR DESCRIPTION
With this PR I propose a slight change to the command-line interface of wft4galaxy, changing the `--xunit` argument to `--output-format <text | xunit>`.  The latter is more generic and can easily accept additional formats, should they arise in the future.